### PR TITLE
bugfix: query array changed after HandleGETRequest

### DIFF
--- a/xss.go
+++ b/xss.go
@@ -230,7 +230,7 @@ func (mw *XssMw) HandleGETRequest(c *gin.Context) error {
 		}
 		queryParams.Del(key)
 		for _, item := range items {
-			queryParams.Set(key, p.Sanitize(item))
+			queryParams.Add(key, p.Sanitize(item))
 		}
 	}
 	c.Request.URL.RawQuery = queryParams.Encode()

--- a/xss_test.go
+++ b/xss_test.go
@@ -810,5 +810,18 @@ func TestUGCPolityAllowSomeHTMLOnPost(t *testing.T) {
 	assert.JSONEq(t, expect, resp.Body.String())
 }
 
+func TestMissingQuery(t *testing.T) {
+	ctx := &gin.Context{
+		Request: &http.Request{},
+	}
+	ctx.Request.URL, _ = url.Parse("http://localhost/foo?k1[]=1&k1[]=2")
+	expected := ctx.Request.URL.Query()["k1[]"]
+	var xss XssMw
+	xss.HandleGETRequest(ctx)
+
+	got := ctx.QueryArray("k1[]")
+	assert.Equal(t, len(expected), len(got), "Check query after handle")
+}
+
 // TODO
 // prove the 3 types of filtering


### PR DESCRIPTION
Query array like "k1[]=1&k1[]=2" cannot be returned by gin.Context.QueryArray after this middleware. So I replace the 'Set' method.